### PR TITLE
Fix makefile and environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VSN=2.0.26a
-ERLC=/usr/local/bin/erlc
-ERL=/usr/local/bin/erl
+ERLC=/usr/bin/env erlc
+ERL=/usr/bin/env erl
 APPDIR= $(abspath ./_build/sinan/lib/sinan-$(VSN))
 SRCDIR=src
 TESTDIR=test
@@ -19,8 +19,8 @@ ERL_TEST_OBJ = $(patsubst test/%.erl,$(BEAMDIR)/%.beam, $(wildcard $(TESTDIR)/*e
 
 all: main
 
-setup: $(COPYDIRS)
-	for f in $^ ; do	\
+setup: 
+	for f in $(COPYDIRS) ; do	\
 		mkdir -p $(APPDIR)/$$f ; \
 		rsync $(RSYNC_OPTIONS) $$f $(APPDIR); \
 	done
@@ -29,34 +29,34 @@ setup: $(COPYDIRS)
 
 build_behaviours: $(BEHAVIOURS)
         # make sure sin_task gets built first so its always available
-	erlc -pa $(BEAMDIR) +warn_export_vars +warn_export_all \
+	$(ERLC) -pa $(BEAMDIR) +warn_export_vars +warn_export_all \
 	+warn_obsolete_guard \
 	+warnings_as_errors +bin_opt_info +debug_info -W -o $(BEAMDIR) $(BEHAVIOURS)
 
 main: setup build_behaviours ${ERL_OBJ} ${ERL_TEST_OBJ}
 
 $(BEAMDIR)/%.beam: %.erl
-	erlc -pa $(BEAMDIR) +warn_export_vars +warn_export_all \
+	$(ERLC) -pa $(BEAMDIR) +warn_export_vars +warn_export_all \
 	+warn_obsolete_guard \
 	+warnings_as_errors +bin_opt_info +debug_info -W -o $(BEAMDIR) $<
 
 build: main
-	erl -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) build
+	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -s sinan main -extra -s $(CURDIR) build
 
 escript: main
-	erl -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) escript
+	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -s sinan main -extra -s $(CURDIR) escript
 
 cucumber: main
-	erl -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) cucumber
+	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -s sinan main -extra -s $(CURDIR) cucumber
 
 proper: main
-	erl -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) proper
+	$(ERL) -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) proper
 
 eunit: main
-	erl -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) eunit
+	$(ERL) -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) eunit
 
 dialyzer: main
-	erl -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) dialyzer
+	$(ERL) -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) dialyzer
 
 run: main
 	$(ERL) -pa $(BEAMDIR)
@@ -76,4 +76,4 @@ gh-pages:
 
 clean:
 	rm -rf _build ;
-	rm -rf erl_crush.dump
+	rm -rf erl_crash.dump

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ $(BEAMDIR)/%.beam: %.erl
 	+warnings_as_errors +bin_opt_info +debug_info -W -o $(BEAMDIR) $<
 
 build: main
-	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -s sinan main -extra -s $(CURDIR) build
+	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -extra -s $(CURDIR) build
 
 escript: main
-	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -s sinan main -extra -s $(CURDIR) escript
+	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -extra -s $(CURDIR) escript
 
 cucumber: main
-	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -s sinan main -extra -s $(CURDIR) cucumber
+	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -extra -s $(CURDIR) cucumber
 
 proper: main
 	$(ERL) -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) proper

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ $(BEAMDIR)/%.beam: %.erl
 	+warnings_as_errors +bin_opt_info +debug_info -W -o $(BEAMDIR) $<
 
 build: main
-	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -extra -s $(CURDIR) build
+	$(ERL) -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) build
 
 escript: main
-	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -extra -s $(CURDIR) escript
+	$(ERL) -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) escript
 
 cucumber: main
-	$(ERL) -pa $(BEAMDIR) -s sinan manual_start -extra -s $(CURDIR) cucumber
+	$(ERL) -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) cucumber
 
 proper: main
 	$(ERL) -pa $(BEAMDIR) -s sinan main -extra -s $(CURDIR) proper


### PR DESCRIPTION
Hi Eric,
I fixed the following things. Maybe you like them.
- define ERLC and ERL based on the binaries found in current PATH
- use $(ERLC) and $(ERL) in all tasks
- remove target requirement $(COPYDIRS) in setup. Use loop inside Makefile instead. Otherwise you may have a name clash when a target has the same same as a directory, like "test".
- fix typo. it's erl_crash.dump not erl_crush.dump
