### PR TITLE
Use new erlware_commons semvar API.

### DIFF
--- a/sinan.config
+++ b/sinan.config
@@ -7,7 +7,7 @@
 
 {dep_constraints,
  [{cucumberl, "0.0.4", gte},
-  {erlware_commons, "0.6.0", gte},
+  {erlware_commons, "0.8.0", gte},
   {getopt, "0.0.1", gte},
   {joxa, "0.0.7a", gte}]}.
 

--- a/src/sin_task_release.erl
+++ b/src/sin_task_release.erl
@@ -219,7 +219,7 @@ make_script(Name, File, Location, Options) ->
     %% Erts 5.9 introduced a non backwards compatible option to
     %% erlang this takes that into account
     Erts = erlang:system_info(version),
-    case Erts == "5.9" orelse ec_string:compare_versions(Erts, "5.9") of
+    case ec_semver:gte(Erts, "5.9") of
         true ->
             systools_make:make_script(Name,
                                       File, [no_warn_sasl,


### PR DESCRIPTION
erlware_commons-0.8.0 replaces ec_string:compare_versions with
ec_semver:gte.

This fixes #94
